### PR TITLE
feat: ✨ add support for github enterprise

### DIFF
--- a/src/GitHub.js
+++ b/src/GitHub.js
@@ -6,8 +6,11 @@ export default class GitHub {
   octokit
   lastResponse = null
 
-  constructor(access_token) {
-    this.octokit = new Octokit({ auth: access_token })
+  constructor(access_token, host = "https://github.com/api/v3") {
+    this.octokit = new Octokit({ 
+      baseUrl: host,
+      auth: access_token 
+    })
     this.init()
   }
 

--- a/src/GitHub.js
+++ b/src/GitHub.js
@@ -1,14 +1,26 @@
 import { Octokit } from 'octokit'
 
+function emptyString(str) {
+  return !str || str.length === 0;
+}
+
+function blankString(str) {
+  return !str || /^\s*$/.test(str);
+}
+
+function isNonValidHost(host) {
+  return emptyString(host) || blankString(host);
+}
+
 export default class GitHub {
   isInitialized = false
   user = null
   octokit
   lastResponse = null
 
-  constructor(access_token, host = "https://github.com/api/v3") {
+  constructor(access_token, host) {
     this.octokit = new Octokit({ 
-      baseUrl: host,
+      baseUrl: isNonValidHost(host) ? undefined : host,
       auth: access_token 
     })
     this.init()

--- a/src/app.js
+++ b/src/app.js
@@ -5,7 +5,7 @@ import GitHub from './GitHub'
 
 const PLUGIN_ID = 'github-api-streamdeck-plugin'
 const IS_URL_REGEX = new RegExp('^https?://.+')
-const FETCH_INTERVAL = 120
+const FETCH_INTERVAL = 60
 const DEFAULT_BG_COLOR = '#cccccc'
 const DEFAULT_BG_COLOR_ERROR = '#ff0000'
 
@@ -31,7 +31,7 @@ function onDidReceiveSettings(json) {
 function onWillDisappear(json) {
   console.info('onWillDisappear', json)
   const context = json.context
-  clearInterval(contextState[context].intervalID)
+  clearInterval(contextState[context].intervalId)
 }
 
 function onWillAppear(json) {
@@ -40,12 +40,11 @@ function onWillAppear(json) {
   setSettings(context, json.payload.settings)
   contextState[context].canvas = new Canvas(context)
   sendQuery(context)
-  contextState[context].intervalID = setInterval(sendQuery, FETCH_INTERVAL * 1000, context)
+  contextState[context].intervalId = setInterval(sendQuery, FETCH_INTERVAL * 1000, context)
 
 }
 
 function onKeyDown(json) {
-  console.log('onKeyDown', json);
   const context = json.context
   const settings = contextState[context].settings
   console.info('onKeyDown', json, settings.on_key_press)

--- a/src/app.js
+++ b/src/app.js
@@ -5,7 +5,7 @@ import GitHub from './GitHub'
 
 const PLUGIN_ID = 'github-api-streamdeck-plugin'
 const IS_URL_REGEX = new RegExp('^https?://.+')
-const FETCH_INTERVAL = 60
+const FETCH_INTERVAL = 120
 const DEFAULT_BG_COLOR = '#cccccc'
 const DEFAULT_BG_COLOR_ERROR = '#ff0000'
 
@@ -13,6 +13,7 @@ $SD.on('connected', onConnected)
 $SD.on(`${PLUGIN_ID}.didReceiveSettings`, onDidReceiveSettings)
 $SD.on(`${PLUGIN_ID}.willAppear`, onWillAppear)
 $SD.on(`${PLUGIN_ID}.keyDown`, onKeyDown)
+$SD.on(`${PLUGIN_ID}.willDisappear`, onWillDisappear)
 
 // key: context, value: state (settings, github, canvas)
 const contextState = {}
@@ -27,18 +28,24 @@ function onDidReceiveSettings(json) {
   sendQuery(json.context)
 }
 
+function onWillDisappear(json) {
+  console.info('onWillDisappear', json)
+  const context = json.context
+  clearInterval(contextState[context].intervalID)
+}
+
 function onWillAppear(json) {
   console.info('onWillAppear', json)
   const context = json.context
   setSettings(context, json.payload.settings)
   contextState[context].canvas = new Canvas(context)
   sendQuery(context)
-  setInterval(() => {
-    sendQuery(context)
-  }, FETCH_INTERVAL * 1000)
+  contextState[context].intervalID = setInterval(sendQuery, FETCH_INTERVAL * 1000, context)
+
 }
 
 function onKeyDown(json) {
+  console.log('onKeyDown', json);
   const context = json.context
   const settings = contextState[context].settings
   console.info('onKeyDown', json, settings.on_key_press)
@@ -65,6 +72,7 @@ function setSettings(context, newSettings) {
   }
   contextState[context].settings = {
     access_token: null,
+    host: null,
     graphql_query: null,
     badge_value_path: null,
     badge_show_condition: null,
@@ -74,9 +82,11 @@ function setSettings(context, newSettings) {
   }
   const settings = contextState[context].settings
   if (newSettings) {
-    if (newSettings.access_token !== settings.access_token) {
+    if ((newSettings.access_token !== settings.access_token)
+      || (newSettings.host !== settings.host)) {
       settings.access_token = newSettings.access_token
-      contextState[context].github = new GitHub(settings.access_token)
+      settings.host = newSettings.host
+      contextState[context].github = new GitHub(settings.access_token, settings.host)
     }
     if (newSettings.graphql_query !== settings.graphql_query) {
       settings.graphql_query = newSettings.graphql_query
@@ -110,6 +120,7 @@ function setSettings(context, newSettings) {
 }
 
 async function sendQuery(context) {
+  console.log('sendQuery', context);
   if (!contextState[context]) {
     return
   }
@@ -154,23 +165,31 @@ async function sendQuery(context) {
 }
 
 function findAndOpenUrls(context, first_only = false, obj) {
-  if (!obj) {
-    obj = contextState[context].github.getLastResponse()
-  }
-  for (const v in obj) {
-    if (typeof obj[v] === 'string') {
-      if (IS_URL_REGEX.test(obj[v])) {
-        $SD.api.openUrl(context, obj[v])
-        if (first_only) {
+  console.log('findAndOpenUrls', context, first_only, obj)
+  try {
+    if (!obj) {
+      obj = contextState[context].github.getLastResponse()
+    }
+    for (const v in obj) {
+      if (typeof obj[v] === 'string') {
+        if (IS_URL_REGEX.test(obj[v])) {
+          $SD.api.openUrl(context, obj[v])
+          if (first_only) {
+            return true
+          }
+        }
+      } else if (typeof obj[v] === 'object') {
+        const foundUrl = findAndOpenUrls(context, first_only, obj[v])
+        if (foundUrl) {
           return true
         }
       }
-    } else if (typeof obj[v] === 'object') {
-      const foundUrl = findAndOpenUrls(context, first_only, obj[v])
-      if (foundUrl) {
-        return true
-      }
     }
+    return false
+  } catch (e) {
+    console.error(e)
+    const settings = contextState[context].settings
+    const errorColor = _get(settings.status_colors, 'error', DEFAULT_BG_COLOR_ERROR)
+    contextState[context].canvas.set({ badgeText: '', bgColor: '' + errorColor })
   }
-  return false
 }

--- a/src/pi.html
+++ b/src/pi.html
@@ -12,6 +12,12 @@
       <div class="sdpi-heading">Query</div>
       <div class="sdpi-item">
         <div class="sdpi-item-label">
+          GitHub API url          
+        </div>
+        <input id="host" class="sdpi-item-value" type="url" placeholder="https://github.com/api/v3"/>
+      </div>
+      <div class="sdpi-item">
+        <div class="sdpi-item-label">
           <a
             data-open-url="https://github.com/settings/tokens"
             href="https://github.com/settings/tokens"

--- a/src/pi.js
+++ b/src/pi.js
@@ -24,7 +24,7 @@ $SD.on('didReceiveSettings', jsonObj => {
   if (jsonObj && jsonObj.payload && jsonObj.payload.settings) {
     settings = jsonObj.payload.settings
     populateSettings(settings)
-    github = new GitHub(settings.access_token)
+    github = new GitHub(settings.access_token, settings.host)
   }
 
   revealSdpiWrapper()
@@ -296,6 +296,6 @@ function handleSdpiItemChange(e, idx) {
   if ($SD && $SD.connection) {
     console.log('setSettings(): ', settings)
     $SD.api.setSettings($SD.uuid, settings)
-    github = new GitHub(settings.access_token)
+    github = new GitHub(settings.access_token, settings.host)
   }
 }


### PR DESCRIPTION
Changes:
- enable "github api url" input. That input allows you to set an enterprise host.
- clearInterval on willDisappear event. That avoids the creation of infinite intervals every time you switch between profiles or pages.
- Increase refresh interval. That avoids unnecessary calls when you have several github buttons.